### PR TITLE
Update amazon-echo-ha-bridge.xml

### DIFF
--- a/aptalca/amazon-echo-ha-bridge.xml
+++ b/aptalca/amazon-echo-ha-bridge.xml
@@ -22,6 +22,13 @@
   <Privileged>false</Privileged>
   <Networking>
     <Mode>host</Mode>
+    <Publish>
+<Port>
+<HostPort>8080</HostPort>
+<ContainerPort>8080</ContainerPort>
+<Protocol>tcp</Protocol>
+      </Port>
+    </Publish>
   </Networking>
   <Environment>
     <Variable>


### PR DESCRIPTION
changes to the amazon template should enable webui to be shown in unraid.
